### PR TITLE
☑️ Make DataDog API site configurable

### DIFF
--- a/src/commands/init-config.ts
+++ b/src/commands/init-config.ts
@@ -28,6 +28,11 @@ export function registerInitConfigCommand(program: Denomander): void {
       Deno.env.get("DATADOG_APP_KEY"),
     )
     .option(
+      "-s, --site",
+      "Datadog site (e.g datadoghq.eu)",
+      identity,
+    )
+    .option(
       "-p, --path",
       "Path to save the config file",
       identity,
@@ -35,7 +40,7 @@ export function registerInitConfigCommand(program: Denomander): void {
     )
     .action(
       async (
-        options: { path: string; "api-key": string; "app-key": string },
+        options: { path: string; "api-key": string; "app-key": string; "site": string },
       ) => {
         try {
           // Check if the file already exists
@@ -280,6 +285,7 @@ We'll scan for ${providerName} services and add them to your config file.`,
               const datadogService = new DatadogService({
                 apiKey: options["api-key"],
                 appKey: options["app-key"],
+                site: options["site"],
               });
 
               // Get all monitors to detect PagerDuty services

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ Deno.addSignalListener("SIGINT", () => {
 // Parse Deno args
 try {
   program.parse(Deno.args);
-} catch (error) {
+} catch (error: any) {
   console.error(error.message);
   program.showHelp();
 }

--- a/src/services/datadog.ts
+++ b/src/services/datadog.ts
@@ -13,7 +13,7 @@ export class DatadogService {
   private monitorsApi: v1.MonitorsApi;
   private webhooksApi: v1.WebhooksIntegrationApi;
 
-  constructor({ apiKey, appKey }: { apiKey: string; appKey: string }) {
+  constructor({ apiKey, appKey, site }: { apiKey: string; appKey: string; site: string }) {
     // Validate credentials
     if (!apiKey || !appKey) {
       throw new Error(
@@ -28,6 +28,13 @@ export class DatadogService {
         appKeyAuth: appKey,
       },
     });
+
+    // Set the site (e.g datadoghq.eu) if provided
+    if (site) {
+      configuration.setServerVariables({
+        site: site,
+      });
+    }
 
     debug("Created Datadog API client configuration");
 

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -10,6 +10,9 @@ export interface BaseCommandOptions {
   "api-key": string;
   "app-key": string;
 
+  // Datadog site (e.g datadoghq.eu)
+  "site": string;
+
   // Config path
   config: string;
 }
@@ -61,6 +64,10 @@ export const CommandOptions = {
     flag: "-a, --app-key",
     description: "Datadog App key",
     defaultEnv: "DATADOG_APP_KEY",
+  },
+  site: {
+    flag: "-s, --site",
+    description: "Datadog site (e.g datadoghq.eu)",
   },
   
   // Config option

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -21,10 +21,12 @@ export { CommandOptions };
 export function createDatadogService(options: {
   "api-key": string;
   "app-key": string;
+  "site": string;
 }): DatadogService {
   return new DatadogService({
     apiKey: options["api-key"],
     appKey: options["app-key"],
+    site: options["site"],
   });
 }
 
@@ -80,6 +82,11 @@ export function setupAuthOptions(command: Denomander): Denomander {
       CommandOptions.appKey.description,
       identity,
       Deno.env.get(CommandOptions.appKey.defaultEnv),
+    )
+    .option(
+      CommandOptions.site.flag,
+      CommandOptions.site.description,
+      identity,
     );
 }
 


### PR DESCRIPTION
### Summary

Currently, the tool does not allow selecting the EU API site. This caused repeated `403` errors until I realized the issue was due to the API site (EU or US) being neither configurable nor pre-configured.

### Changes

- Added support for configuring the API site (EU or US).
- Updated the code so that requests correctly target the selected region.

### Motivation

I needed to test the migrator against the EU API site, but without this change, it was impossible. The fix makes the tool usable in both regions and avoids the confusion of unexplained `403` errors.
